### PR TITLE
Dmrs chest parameters extraction

### DIFF
--- a/lib/include/srsran/AO_general.h
+++ b/lib/include/srsran/AO_general.h
@@ -12,6 +12,10 @@
 #define TMSI_TO_IMSI_FILE_NAME "/tmp/tmsi_to_imsi.csv"
 #define PUSCH_SNR_FILE "/tmp/pusch_snr_rnti.csv"
 #define PUCCH_SNR_FILE "/tmp/pucch_snr_rnti.csv"
+// Channel estimation files
+#define PUSCH_CHEST_FILE "/tmp/pusch_chest.csv"
+#define PUCCH_CHEST_FILE "/tmp/pucch_chest.csv"
+
 #define WB_CQI_FILE      "/tmp/wb_cqi.csv"
 //#define SB_CQI_LOG      "SB_CQI.csv"
 #define SB_CQI_FILE    "/tmp/sb_cqi.csv"
@@ -90,6 +94,8 @@ class AO_LogsHelper
         create_tmsi_to_imsi_file();
         create_pusch_snr_file();
         create_pucch_snr_file();
+        create_pusch_chest_file();
+        create_pucch_chest_file();
         create_wb_cqi_file();
         create_sb_cqi_file();
         create_pmi_file();
@@ -146,6 +152,17 @@ class AO_LogsHelper
     {        
         createLookupFile(PUCCH_SNR_FILE,"time stamp,time stamp double,rnti,snr,detected");
     };
+
+    // Channel estimation files
+    void static create_pusch_chest_file()
+    {
+        createLookupFile(PUSCH_CHEST_FILE,"time stamp,time stamp double,rnti,rsrp,epre,noise_est"); // Remember to change the header
+    };
+    void static create_pucch_chest_file()
+    {
+        createLookupFile(PUCCH_CHEST_FILE,"time stamp,time stamp double,rnti,rsrp,epre,noise_est");
+    };
+
     void static create_wb_cqi_file()
     {        
         createLookupFile(WB_CQI_FILE,"time stamp,time stamp double,rnti,scell_index,wb_cqi");

--- a/lib/include/srsran/AO_general.h
+++ b/lib/include/srsran/AO_general.h
@@ -160,7 +160,7 @@ class AO_LogsHelper
     };
     void static create_pucch_chest_file()
     {
-        createLookupFile(PUCCH_CHEST_FILE,"time stamp,time stamp double,rnti,rsrp,epre,noise_est");
+        createLookupFile(PUCCH_CHEST_FILE,"time stamp,time stamp double,rnti,rsrp,epre,noise_est,detected");
     };
 
     void static create_wb_cqi_file()

--- a/lib/include/srsran/AO_general.h
+++ b/lib/include/srsran/AO_general.h
@@ -87,6 +87,7 @@ class AO_LogsHelper
     void static create_log_files()
     {
         create_rnti_to_tmsi_file();
+        create_tmsi_to_imsi_file();
         create_pusch_snr_file();
         create_pucch_snr_file();
         create_wb_cqi_file();

--- a/srsenb/hdr/phy/lte/cc_worker.h
+++ b/srsenb/hdr/phy/lte/cc_worker.h
@@ -68,6 +68,9 @@ private:
   // AO start
   std::ofstream pusch_snr_file;
   std::ofstream pucch_snr_file;
+  // Channel estimation files
+  std::ofstream pusch_chest_file;
+  std::ofstream pucch_chest_file;
   // AO end
   constexpr static float PUSCH_RL_SNR_DB_TH = 1.0f;
   constexpr static float PUCCH_RL_CORR_TH   = 0.15f;


### PR DESCRIPTION
Added what is needed to extract parameters related to PUSCH and PUCCH Channel Estimation DMRS, namely, RSRP and EPRE and noise_estimation. 

Modifications include first creating the log files and writing their headers using AO_general.cc functions, then declaring the file stream in srsRAN_4G/srsenb/hdr/phy/lte/cc_worker.h, and finally accessing the required parameters in srsRAN_4G/srsenb/src/phy/lte/cc_worker.cc and dumping it to the log files.

Also, fixed a bug where the tmsi_to_imsi log file was being generated without a header. One line was missing and it was added. check the commit da72b4ce864ae4d54a8ecb1fc2a2e03c8f67d3f0. 